### PR TITLE
Run neovim in a Docker sandbox to isolate plugins from host credentials

### DIFF
--- a/bin/nvim
+++ b/bin/nvim
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_hash=$(echo -n "$PWD" | md5sum | cut -c1-12)
+state_dir="$HOME/.local/state/nvim-sandbox/$project_hash"
+cache_dir="$HOME/.cache/nvim-sandbox/$project_hash"
+bundle_dir="$HOME/.local/share/nvim-sandbox/bundle/$project_hash"
+share_dir="$HOME/.local/share/nvim-sandbox"
+rubies_dir="$HOME/.local/share/nvim-sandbox/rubies"
+
+mkdir -p "$state_dir" "$cache_dir" "$bundle_dir" "$share_dir" "$rubies_dir"
+
+docker run --rm -it \
+  -v "$HOME/.config/nvim:/home/nvimuser/.config/nvim:ro" \
+  -v "$share_dir:/home/nvimuser/.local/share/nvim" \
+  -v "$state_dir:/home/nvimuser/.local/state/nvim" \
+  -v "$cache_dir:/home/nvimuser/.cache/nvim" \
+  -v "$PWD:/home/nvimuser/work" \
+  -v "$rubies_dir:/home/nvimuser/.rubies" \
+  -v "$bundle_dir:/home/nvimuser/.gem-cache" \
+  -e BUNDLE_PATH="/home/nvimuser/.gem-cache" \
+  -v "$DOTFILES/bin/run_in_split:/usr/local/bin/run_in_split:ro" \
+  -v "/tmp/tmux-$(id -u):/tmp/tmux-$(id -u)" \
+  -w /home/nvimuser/work \
+  -e TERM="$TERM" \
+  -e HOST_PWD="$PWD" \
+  ${TMUX:+-e TMUX="$TMUX" -e TMUX_PANE="$TMUX_PANE"} \
+  --network=host \
+  --name "nvim-$$" \
+  nvim-sandbox \
+  nvim "$@"

--- a/bin/nvim
+++ b/bin/nvim
@@ -10,6 +10,24 @@ rubies_dir="$HOME/.local/share/nvim-sandbox/rubies"
 
 mkdir -p "$state_dir" "$cache_dir" "$bundle_dir" "$share_dir" "$rubies_dir"
 
+# Build extra mounts for file arguments outside $PWD
+extra_mounts=()
+for arg in "$@"; do
+  # Skip flags (starts with - or +)
+  [[ "$arg" == -* || "$arg" == +* ]] && continue
+  # Resolve to absolute path
+  if [[ "$arg" == /* ]]; then
+    filepath="$arg"
+  else
+    filepath="$PWD/$arg"
+  fi
+  dir="$(dirname "$filepath")"
+  # Only add mount if not already under $PWD
+  if [[ "$dir" != "$PWD"* ]]; then
+    extra_mounts+=(-v "$dir:$dir")
+  fi
+done
+
 docker run --rm -it \
   -v "$HOME/.config/nvim:/home/nvimuser/.config/nvim:ro" \
   -v "$HOME/.claude:/home/nvimuser/.claude" \
@@ -28,6 +46,7 @@ docker run --rm -it \
   -e HOST_PWD="$PWD" \
   ${TMUX:+-e TMUX="$TMUX" -e TMUX_PANE="$TMUX_PANE"} \
   --network=host \
+  "${extra_mounts[@]}" \
   --name "nvim-$$" \
   nvim-sandbox \
   nvim "$@"

--- a/bin/nvim
+++ b/bin/nvim
@@ -7,8 +7,9 @@ cache_dir="$HOME/.cache/nvim-sandbox/$project_hash"
 bundle_dir="$HOME/.local/share/nvim-sandbox/bundle/$project_hash"
 share_dir="$HOME/.local/share/nvim-sandbox"
 rubies_dir="$HOME/.local/share/nvim-sandbox/rubies"
+gems_dir="$HOME/.local/share/nvim-sandbox/gems"
 
-mkdir -p "$state_dir" "$cache_dir" "$bundle_dir" "$share_dir" "$rubies_dir"
+mkdir -p "$state_dir" "$cache_dir" "$bundle_dir" "$share_dir" "$rubies_dir" "$gems_dir"
 
 # Build extra mounts for file arguments outside $PWD
 extra_mounts=()
@@ -32,12 +33,13 @@ docker run --rm -it \
   -v "$HOME/.config/nvim:/home/nvimuser/.config/nvim:ro" \
   -v "$HOME/.claude:/home/nvimuser/.claude" \
   -v "$HOME/.claude.json:/home/nvimuser/.claude.json" \
-  -v "$HOME/.config/github-copilot:/home/nvimuser/.config/github-copilot:ro" \
+  -v "$HOME/.config/github-copilot:/home/nvimuser/.config/github-copilot" \
   -v "$share_dir:/home/nvimuser/.local/share/nvim" \
   -v "$state_dir:/home/nvimuser/.local/state/nvim" \
   -v "$cache_dir:/home/nvimuser/.cache/nvim" \
   -v "$PWD:$PWD" \
   -v "$rubies_dir:/home/nvimuser/.rubies" \
+  -v "$gems_dir:/home/nvimuser/.gem" \
   -v "$bundle_dir:/home/nvimuser/.gem-cache" \
   -e BUNDLE_PATH="/home/nvimuser/.gem-cache" \
   -v "$DOTFILES/bin/run_in_split:/usr/local/bin/run_in_split:ro" \

--- a/bin/nvim
+++ b/bin/nvim
@@ -15,13 +15,13 @@ docker run --rm -it \
   -v "$share_dir:/home/nvimuser/.local/share/nvim" \
   -v "$state_dir:/home/nvimuser/.local/state/nvim" \
   -v "$cache_dir:/home/nvimuser/.cache/nvim" \
-  -v "$PWD:/home/nvimuser/work" \
+  -v "$PWD:$PWD" \
   -v "$rubies_dir:/home/nvimuser/.rubies" \
   -v "$bundle_dir:/home/nvimuser/.gem-cache" \
   -e BUNDLE_PATH="/home/nvimuser/.gem-cache" \
   -v "$DOTFILES/bin/run_in_split:/usr/local/bin/run_in_split:ro" \
   -v "/tmp/tmux-$(id -u):/tmp/tmux-$(id -u)" \
-  -w /home/nvimuser/work \
+  -w "$PWD" \
   -e TERM="$TERM" \
   -e HOST_PWD="$PWD" \
   ${TMUX:+-e TMUX="$TMUX" -e TMUX_PANE="$TMUX_PANE"} \

--- a/bin/nvim
+++ b/bin/nvim
@@ -32,6 +32,7 @@ docker run --rm -it \
   -v "$HOME/.config/nvim:/home/nvimuser/.config/nvim:ro" \
   -v "$HOME/.claude:/home/nvimuser/.claude" \
   -v "$HOME/.claude.json:/home/nvimuser/.claude.json" \
+  -v "$HOME/.config/github-copilot:/home/nvimuser/.config/github-copilot:ro" \
   -v "$share_dir:/home/nvimuser/.local/share/nvim" \
   -v "$state_dir:/home/nvimuser/.local/state/nvim" \
   -v "$cache_dir:/home/nvimuser/.cache/nvim" \

--- a/bin/nvim
+++ b/bin/nvim
@@ -43,7 +43,7 @@ docker run --rm -it \
   -v "$bundle_dir:/home/nvimuser/.gem-cache" \
   -e BUNDLE_PATH="/home/nvimuser/.gem-cache" \
   -v "$DOTFILES/bin/run_in_split:/usr/local/bin/run_in_split:ro" \
-  -v "/tmp/tmux-$(id -u):/tmp/tmux-$(id -u)" \
+  ${TMUX:+-v "$(dirname "${TMUX%%,*}"):$(dirname "${TMUX%%,*}")"} \
   -w "$PWD" \
   -e TERM="$TERM" \
   -e HOST_PWD="$PWD" \

--- a/bin/nvim
+++ b/bin/nvim
@@ -12,6 +12,8 @@ mkdir -p "$state_dir" "$cache_dir" "$bundle_dir" "$share_dir" "$rubies_dir"
 
 docker run --rm -it \
   -v "$HOME/.config/nvim:/home/nvimuser/.config/nvim:ro" \
+  -v "$HOME/.claude:/home/nvimuser/.claude" \
+  -v "$HOME/.claude.json:/home/nvimuser/.claude.json" \
   -v "$share_dir:/home/nvimuser/.local/share/nvim" \
   -v "$state_dir:/home/nvimuser/.local/state/nvim" \
   -v "$cache_dir:/home/nvimuser/.cache/nvim" \

--- a/bin/nvim-bundle-install
+++ b/bin/nvim-bundle-install
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_hash=$(echo -n "$PWD" | md5sum | cut -c1-12)
+bundle_dir="$HOME/.local/share/nvim-sandbox/bundle/$project_hash"
+rubies_dir="$HOME/.local/share/nvim-sandbox/rubies"
+
+mkdir -p "$bundle_dir" "$rubies_dir"
+
+docker run --rm -it \
+  -v "$PWD:/home/nvimuser/work" \
+  -v "$rubies_dir:/home/nvimuser/.rubies" \
+  -v "$bundle_dir:/home/nvimuser/.gem-cache" \
+  -e BUNDLE_PATH="/home/nvimuser/.gem-cache" \
+  -w /home/nvimuser/work \
+  --network=host \
+  nvim-sandbox \
+  bash -lc 'source /usr/share/chruby/chruby.sh && source /usr/share/chruby/auto.sh && chruby_auto && bundle install'

--- a/bin/nvim-bundle-install
+++ b/bin/nvim-bundle-install
@@ -4,14 +4,19 @@ set -euo pipefail
 project_hash=$(echo -n "$PWD" | md5sum | cut -c1-12)
 bundle_dir="$HOME/.local/share/nvim-sandbox/bundle/$project_hash"
 rubies_dir="$HOME/.local/share/nvim-sandbox/rubies"
+gems_dir="$HOME/.local/share/nvim-sandbox/gems"
 
-mkdir -p "$bundle_dir" "$rubies_dir"
+mkdir -p "$bundle_dir" "$rubies_dir" "$gems_dir"
 
 docker run --rm -it \
   -v "$PWD:/home/nvimuser/work" \
   -v "$rubies_dir:/home/nvimuser/.rubies" \
+  -v "$gems_dir:/home/nvimuser/.gem" \
   -v "$bundle_dir:/home/nvimuser/.gem-cache" \
   -e BUNDLE_PATH="/home/nvimuser/.gem-cache" \
+  -v "$HOME/.ssh:/home/nvimuser/.ssh:ro" \
+  -v "$HOME/.gitconfig:/home/nvimuser/.gitconfig:ro" \
+  -v "$HOME/.bundle:/home/nvimuser/.bundle" \
   -w /home/nvimuser/work \
   --network=host \
   nvim-sandbox \

--- a/bin/nvim-ruby-install
+++ b/bin/nvim-ruby-install
@@ -10,14 +10,16 @@ fi
 version="$1"
 share_dir="$HOME/.local/share/nvim-sandbox"
 rubies_dir="$share_dir/rubies"
+gems_dir="$share_dir/gems"
 
-mkdir -p "$rubies_dir"
+mkdir -p "$rubies_dir" "$gems_dir"
 
 docker run --rm -it \
   -v "$rubies_dir:/home/nvimuser/.rubies" \
+  -v "$gems_dir:/home/nvimuser/.gem" \
   --network=host \
   nvim-sandbox \
-  bash -c "ruby-install --no-install-deps ruby $version \
+  bash -c "ruby-install --no-install-deps ruby-$version \
     && source /usr/share/chruby/chruby.sh \
     && chruby ruby-$version \
     && gem install ruby-lsp ruby-lsp-rails rubocop"

--- a/bin/nvim-ruby-install
+++ b/bin/nvim-ruby-install
@@ -22,4 +22,4 @@ docker run --rm -it \
   bash -c "ruby-install --no-install-deps ruby-$version \
     && source /usr/share/chruby/chruby.sh \
     && chruby ruby-$version \
-    && gem install ruby-lsp ruby-lsp-rails rubocop"
+    && gem install bundler ruby-lsp ruby-lsp-rails rubocop rubocop-rspec"

--- a/bin/nvim-ruby-install
+++ b/bin/nvim-ruby-install
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${1:-}" ]; then
+  echo "Usage: nvim-ruby-install <version>"
+  echo "Example: nvim-ruby-install 3.2.0"
+  exit 1
+fi
+
+version="$1"
+share_dir="$HOME/.local/share/nvim-sandbox"
+rubies_dir="$share_dir/rubies"
+
+mkdir -p "$rubies_dir"
+
+docker run --rm -it \
+  -v "$rubies_dir:/home/nvimuser/.rubies" \
+  --network=host \
+  nvim-sandbox \
+  bash -c "ruby-install --no-install-deps ruby $version \
+    && source /usr/share/chruby/chruby.sh \
+    && chruby ruby-$version \
+    && gem install ruby-lsp ruby-lsp-rails rubocop"

--- a/bin/nvim-ruby-install
+++ b/bin/nvim-ruby-install
@@ -14,6 +14,11 @@ gems_dir="$share_dir/gems"
 
 mkdir -p "$rubies_dir" "$gems_dir"
 
+if [ -d "$rubies_dir/ruby-$version" ]; then
+  echo "Ruby $version already installed, skipping."
+  exit 0
+fi
+
 docker run --rm -it \
   -v "$rubies_dir:/home/nvimuser/.rubies" \
   -v "$gems_dir:/home/nvimuser/.gem" \

--- a/bin/nvim-ruby-install
+++ b/bin/nvim-ruby-install
@@ -16,6 +16,16 @@ mkdir -p "$rubies_dir" "$gems_dir"
 
 if [ -d "$rubies_dir/ruby-$version" ]; then
   echo "Ruby $version already installed, skipping."
+
+  echo "Installing gems for Ruby $version..."
+  docker run --rm -it \
+    -v "$rubies_dir:/home/nvimuser/.rubies" \
+    -v "$gems_dir:/home/nvimuser/.gem" \
+    --network=host \
+    nvim-sandbox \
+    bash -c "source /usr/share/chruby/chruby.sh \
+      && chruby ruby-$version \
+      && gem install bundler ruby-lsp ruby-lsp-rails rubocop rubocop-rspec"
   exit 0
 fi
 

--- a/bin/run_in_split
+++ b/bin/run_in_split
@@ -24,4 +24,8 @@ if [ "$($TMUX_COMMAND display-message -p '#{window_zoomed_flag}')" = '1' ]; then
   $TMUX_COMMAND resize-pane -Z -t "$CURRENT_PANE_ID"
 fi
 
-$TMUX_COMMAND send-keys -t "$TMUX_SPLIT_ID" "$* && $TMUX_COMMAND resize-pane -Z -t $CURRENT_PANE_ID" C-m
+if [ -n "${HOST_PWD:-}" ]; then
+  $TMUX_COMMAND send-keys -t "$TMUX_SPLIT_ID" "cd $HOST_PWD && $* && $TMUX_COMMAND resize-pane -Z -t $CURRENT_PANE_ID" C-m
+else
+  $TMUX_COMMAND send-keys -t "$TMUX_SPLIT_ID" "$* && $TMUX_COMMAND resize-pane -Z -t $CURRENT_PANE_ID" C-m
+fi

--- a/neovim/.config/nvim/init.lua
+++ b/neovim/.config/nvim/init.lua
@@ -33,7 +33,12 @@ vim.opt.runtimepath:prepend(lazypath)
 
 _G.tests = require('tests')
 
-require('lazy').setup('plugins')
+local lazy_opts = {}
+if vim.env.NVIM_CONTAINER then
+  lazy_opts.lockfile = vim.fn.stdpath('data') .. '/lazy-lock.json'
+end
+
+require('lazy').setup('plugins', lazy_opts)
 
 require('init/maps')
 require('init/lsp')

--- a/neovim/.config/nvim/lsp/gopls.lua
+++ b/neovim/.config/nvim/lsp/gopls.lua
@@ -6,18 +6,15 @@ return {
     vim.api.nvim_create_autocmd("BufWritePre", {
       buffer = bufnr,
       callback = function()
-        local params = vim.lsp.util.make_range_params()
+        local clients = vim.lsp.get_clients({ bufnr = bufnr, name = 'gopls' })
+        if #clients == 0 then return end
+        local enc = clients[1].offset_encoding or "utf-16"
+        local params = vim.lsp.util.make_range_params(nil, enc)
         params.context = {only = {"source.organizeImports"}}
-        -- buf_request_sync defaults to a 1000ms timeout. Depending on your
-        -- machine and codebase, you may want longer. Add an additional
-        -- argument after params if you find that you have to write the file
-        -- twice for changes to be saved.
-        -- E.g., vim.lsp.buf_request_sync(0, "textDocument/codeAction", params, 3000)
         local result = vim.lsp.buf_request_sync(0, "textDocument/codeAction", params)
-        for cid, res in pairs(result or {}) do
+        for _, res in pairs(result or {}) do
           for _, r in pairs(res.result or {}) do
             if r.edit then
-              local enc = (vim.lsp.get_client_by_id(cid) or {}).offset_encoding or "utf-16"
               vim.lsp.util.apply_workspace_edit(r.edit, enc)
             end
           end

--- a/neovim/.config/nvim/lsp/rubocop.lua
+++ b/neovim/.config/nvim/lsp/rubocop.lua
@@ -1,5 +1,7 @@
 return {
-  cmd = { 'rubocop', '--lsp' },
+  cmd = vim.env.NVIM_CONTAINER
+    and { 'bash', '-c', 'source /usr/share/chruby/chruby.sh && chruby "$(cat .ruby-version 2>/dev/null || ls ~/.rubies | sort -V | tail -1)" && rubocop --lsp' }
+    or { 'zsh', '-l', '-c', 'source ~/.zsh/functions/chruby_auto.sh && chruby_auto && rubocop --lsp' },
   filetypes = { 'ruby' },
   root_markers = { 'Gemfile', '.git' },
   on_attach = function(client, bufnr)

--- a/neovim/.config/nvim/lsp/ruby_lsp.lua
+++ b/neovim/.config/nvim/lsp/ruby_lsp.lua
@@ -1,5 +1,7 @@
 return {
-  cmd = { 'zsh', '-l', '-c', 'source ~/.zsh/functions/chruby_auto.sh && chruby_auto && ruby-lsp' },
+  cmd = vim.env.NVIM_CONTAINER
+    and { 'bash', '-c', 'source /usr/share/chruby/chruby.sh && source /usr/share/chruby/auto.sh && chruby_auto && ruby-lsp' }
+    or { 'zsh', '-l', '-c', 'source ~/.zsh/functions/chruby_auto.sh && chruby_auto && ruby-lsp' },
   filetypes = { 'ruby' },
   root_markers = { 'Gemfile', '.git' },
   init_options = {

--- a/neovim/.config/nvim/lsp/ruby_lsp.lua
+++ b/neovim/.config/nvim/lsp/ruby_lsp.lua
@@ -1,6 +1,6 @@
 return {
   cmd = vim.env.NVIM_CONTAINER
-    and { 'bash', '-c', 'source /usr/share/chruby/chruby.sh && source /usr/share/chruby/auto.sh && chruby_auto && ruby-lsp' }
+    and { 'bash', '-c', 'source /usr/share/chruby/chruby.sh && chruby "$(cat .ruby-version 2>/dev/null || ls ~/.rubies | sort -V | tail -1)" && ruby-lsp' }
     or { 'zsh', '-l', '-c', 'source ~/.zsh/functions/chruby_auto.sh && chruby_auto && ruby-lsp' },
   filetypes = { 'ruby' },
   root_markers = { 'Gemfile', '.git' },

--- a/neovim/.config/nvim/lua/init/settings.lua
+++ b/neovim/.config/nvim/lua/init/settings.lua
@@ -46,7 +46,7 @@ vim.opt.exrc = true
 vim.opt.winborder = 'double'
 
 if vim.env.NVIM_CONTAINER then
-  local paste_cmd = vim.fn.system("tmux run-shell 'command -v wl-paste'"):find('wl%-paste')
+  local paste_cmd = vim.fn.system('tmux show-environment WAYLAND_DISPLAY 2>/dev/null'):find('WAYLAND_DISPLAY=')
     and 'wl-paste --no-newline'
     or 'xclip -sel clip -o'
 

--- a/neovim/.config/nvim/lua/init/settings.lua
+++ b/neovim/.config/nvim/lua/init/settings.lua
@@ -53,8 +53,27 @@ if vim.env.NVIM_CONTAINER then
       ['*'] = require('vim.ui.clipboard.osc52').copy('*'),
     },
     paste = {
-      ['+'] = function() return { vim.fn.system('tmux save-buffer -'), '' } end,
-      ['*'] = function() return { vim.fn.system('tmux save-buffer -'), '' } end,
+      ['+'] = function()
+        -- run xclip on the host (via tmux server) and sync into tmux's paste buffer
+        vim.fn.system(
+          "tmux run-shell 'xclip -sel clip -o > /tmp/.nvim_clip 2>/dev/null && " ..
+          "[ -s /tmp/.nvim_clip ] && tmux load-buffer /tmp/.nvim_clip'"
+        )
+        local content = vim.fn.system('tmux save-buffer -')
+        local lines = vim.split(content, '\n', { plain = true })
+        if lines[#lines] == '' then table.remove(lines) end
+        return { lines, 'v' }
+      end,
+      ['*'] = function()
+        vim.fn.system(
+          "tmux run-shell 'xclip -sel clip -o > /tmp/.nvim_clip 2>/dev/null && " ..
+          "[ -s /tmp/.nvim_clip ] && tmux load-buffer /tmp/.nvim_clip'"
+        )
+        local content = vim.fn.system('tmux save-buffer -')
+        local lines = vim.split(content, '\n', { plain = true })
+        if lines[#lines] == '' then table.remove(lines) end
+        return { lines, 'v' }
+      end,
     },
   }
 end

--- a/neovim/.config/nvim/lua/init/settings.lua
+++ b/neovim/.config/nvim/lua/init/settings.lua
@@ -9,7 +9,11 @@ vim.g.netrw_bufsettings = 'noma nomod nu nobl nowrap ro'
 vim.opt.signcolumn = 'yes'
 vim.opt.backspace = 'indent,start,eol'
 vim.opt.backupcopy = 'yes'
-vim.opt.backupdir = config .. '/tmp//'
+if vim.env.NVIM_CONTAINER then
+  vim.opt.backupdir = home .. '/.cache/nvim/backup//'
+else
+  vim.opt.backupdir = config .. '/tmp//'
+end
 vim.opt.encoding = 'utf-8'
 vim.opt.expandtab = true
 vim.opt.fileencoding = 'utf-8'
@@ -40,3 +44,17 @@ vim.opt.wrap = false
 vim.opt.mouse = ''
 vim.opt.exrc = true
 vim.opt.winborder = 'double'
+
+if vim.env.NVIM_CONTAINER then
+  vim.g.clipboard = {
+    name = 'OSC 52 + tmux paste',
+    copy = {
+      ['+'] = require('vim.ui.clipboard.osc52').copy('+'),
+      ['*'] = require('vim.ui.clipboard.osc52').copy('*'),
+    },
+    paste = {
+      ['+'] = function() return { vim.fn.system('tmux save-buffer -'), '' } end,
+      ['*'] = function() return { vim.fn.system('tmux save-buffer -'), '' } end,
+    },
+  }
+end

--- a/neovim/.config/nvim/lua/init/settings.lua
+++ b/neovim/.config/nvim/lua/init/settings.lua
@@ -46,6 +46,21 @@ vim.opt.exrc = true
 vim.opt.winborder = 'double'
 
 if vim.env.NVIM_CONTAINER then
+  local paste_cmd = vim.fn.system("tmux run-shell 'command -v wl-paste'"):find('wl%-paste')
+    and 'wl-paste --no-newline'
+    or 'xclip -sel clip -o'
+
+  local function paste_from_host()
+    vim.fn.system(
+      "tmux run-shell '" .. paste_cmd .. " > /tmp/.nvim_clip 2>/dev/null && " ..
+      "[ -s /tmp/.nvim_clip ] && tmux load-buffer /tmp/.nvim_clip'"
+    )
+    local content = vim.fn.system('tmux save-buffer -')
+    local lines = vim.split(content, '\n', { plain = true })
+    if lines[#lines] == '' then table.remove(lines) end
+    return { lines, 'v' }
+  end
+
   vim.g.clipboard = {
     name = 'OSC 52 + tmux paste',
     copy = {
@@ -53,27 +68,8 @@ if vim.env.NVIM_CONTAINER then
       ['*'] = require('vim.ui.clipboard.osc52').copy('*'),
     },
     paste = {
-      ['+'] = function()
-        -- run xclip on the host (via tmux server) and sync into tmux's paste buffer
-        vim.fn.system(
-          "tmux run-shell 'xclip -sel clip -o > /tmp/.nvim_clip 2>/dev/null && " ..
-          "[ -s /tmp/.nvim_clip ] && tmux load-buffer /tmp/.nvim_clip'"
-        )
-        local content = vim.fn.system('tmux save-buffer -')
-        local lines = vim.split(content, '\n', { plain = true })
-        if lines[#lines] == '' then table.remove(lines) end
-        return { lines, 'v' }
-      end,
-      ['*'] = function()
-        vim.fn.system(
-          "tmux run-shell 'xclip -sel clip -o > /tmp/.nvim_clip 2>/dev/null && " ..
-          "[ -s /tmp/.nvim_clip ] && tmux load-buffer /tmp/.nvim_clip'"
-        )
-        local content = vim.fn.system('tmux save-buffer -')
-        local lines = vim.split(content, '\n', { plain = true })
-        if lines[#lines] == '' then table.remove(lines) end
-        return { lines, 'v' }
-      end,
+      ['+'] = paste_from_host,
+      ['*'] = paste_from_host,
     },
   }
 end

--- a/neovim/.config/nvim/lua/plugins/ruby.lua
+++ b/neovim/.config/nvim/lua/plugins/ruby.lua
@@ -2,11 +2,7 @@ return {
   {
     'RRethy/nvim-treesitter-endwise',
     config = function()
-      require('nvim-treesitter.configs').setup {
-        endwise = {
-          enable = true,
-        },
-      }
+      require('nvim-treesitter-endwise').init()
     end
   },
 }

--- a/neovim/docker/Dockerfile
+++ b/neovim/docker/Dockerfile
@@ -33,6 +33,8 @@ RUN yay -S --noconfirm \
     nodejs \
     npm \
     openssl \
+    openssh \
+    postgresql-libs \
     python \
     python-pip \
     ripgrep \

--- a/neovim/docker/Dockerfile
+++ b/neovim/docker/Dockerfile
@@ -23,17 +23,20 @@ RUN git clone https://aur.archlinux.org/yay-bin.git /tmp/yay \
     && cd /tmp/yay && makepkg -si --noconfirm && rm -rf /tmp/yay
 
 # Install everything via yay
-RUN yay -S --noconfirm \
+RUN yay -Sy --noconfirm \
+    buf \
     chruby \
     curl \
     fzf \
     go \
+    golangci-lint \
     libyaml \
+    lua-language-server \
     neovim \
     nodejs \
     npm \
-    openssl \
     openssh \
+    openssl \
     postgresql-libs \
     python \
     python-pip \
@@ -43,12 +46,6 @@ RUN yay -S --noconfirm \
     tmux \
     tree-sitter-cli \
     unzip \
-    && yay -Scc --noconfirm
-
-# LSP servers via yay/pacman
-RUN yay -S --noconfirm \
-    lua-language-server \
-    golangci-lint \
     && yay -Scc --noconfirm
 
 # LSP servers via go
@@ -63,9 +60,6 @@ RUN ruby-install --no-install-deps ruby \
     && source /usr/share/chruby/chruby.sh \
     && chruby ruby \
     && gem install ruby-lsp ruby-lsp-rails rubocop
-
-# buf CLI
-RUN yay -S --noconfirm buf && yay -Scc --noconfirm
 
 # Claude Code CLI
 RUN sudo npm install -g @anthropic-ai/claude-code

--- a/neovim/docker/Dockerfile
+++ b/neovim/docker/Dockerfile
@@ -56,12 +56,6 @@ RUN go install golang.org/x/tools/gopls@latest \
 # LSP servers via npm
 RUN sudo npm install -g typescript typescript-language-server
 
-# Latest Ruby via ruby-install + LSP gems
-RUN ruby-install --no-install-deps ruby \
-    && source /usr/share/chruby/chruby.sh \
-    && chruby ruby \
-    && gem install ruby-lsp ruby-lsp-rails rubocop
-
 # Claude Code CLI
 RUN sudo npm install -g @anthropic-ai/claude-code
 

--- a/neovim/docker/Dockerfile
+++ b/neovim/docker/Dockerfile
@@ -65,6 +65,9 @@ RUN ruby-install --no-install-deps ruby \
 # buf CLI
 RUN yay -S --noconfirm buf && yay -Scc --noconfirm
 
+# Claude Code CLI
+RUN sudo npm install -g @anthropic-ai/claude-code
+
 USER root
 RUN rm /etc/sudoers.d/nvimuser
 USER nvimuser

--- a/neovim/docker/Dockerfile
+++ b/neovim/docker/Dockerfile
@@ -1,0 +1,85 @@
+FROM archlinux:latest
+
+ARG UID=1000
+ARG GID=1000
+
+# Minimal pacman deps needed to bootstrap yay
+RUN pacman -Syu --noconfirm \
+    base-devel \
+    git \
+    sudo \
+    && pacman -Scc --noconfirm
+
+# Non-root user matching host UID/GID
+RUN groupadd -g $GID nvimuser \
+    && useradd -m -u $UID -g $GID -s /bin/bash nvimuser
+
+# Temporary sudo for yay install + package installation
+RUN echo 'nvimuser ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/nvimuser
+USER nvimuser
+
+# AUR helper
+RUN git clone https://aur.archlinux.org/yay-bin.git /tmp/yay \
+    && cd /tmp/yay && makepkg -si --noconfirm && rm -rf /tmp/yay
+
+# Install everything via yay
+RUN yay -S --noconfirm \
+    chruby \
+    curl \
+    fzf \
+    go \
+    libyaml \
+    neovim \
+    nodejs \
+    npm \
+    openssl \
+    python \
+    python-pip \
+    ripgrep \
+    ruby-install \
+    tig \
+    tmux \
+    tree-sitter-cli \
+    unzip \
+    && yay -Scc --noconfirm
+
+# LSP servers via yay/pacman
+RUN yay -S --noconfirm \
+    lua-language-server \
+    golangci-lint \
+    && yay -Scc --noconfirm
+
+# LSP servers via go
+RUN go install golang.org/x/tools/gopls@latest \
+    && go install github.com/nametake/golangci-lint-langserver@latest
+
+# LSP servers via npm
+RUN sudo npm install -g typescript typescript-language-server
+
+# Latest Ruby via ruby-install + LSP gems
+RUN ruby-install --no-install-deps ruby \
+    && source /usr/share/chruby/chruby.sh \
+    && chruby ruby \
+    && gem install ruby-lsp ruby-lsp-rails rubocop
+
+# buf CLI
+RUN yay -S --noconfirm buf && yay -Scc --noconfirm
+
+USER root
+RUN rm /etc/sudoers.d/nvimuser
+USER nvimuser
+
+# Ensure state directories exist with correct ownership
+RUN mkdir -p /home/nvimuser/.local/share/nvim \
+             /home/nvimuser/.local/state/nvim \
+             /home/nvimuser/.cache/nvim \
+    && chown -R nvimuser:nvimuser /home/nvimuser
+
+ENV PATH="/home/nvimuser/go/bin:/usr/local/go/bin:$PATH"
+ENV NVIM_CONTAINER=1
+
+# chruby + chruby-auto for per-project ruby version switching
+RUN echo 'source /usr/share/chruby/chruby.sh' >> /home/nvimuser/.bashrc \
+    && echo 'source /usr/share/chruby/auto.sh' >> /home/nvimuser/.bashrc
+
+WORKDIR /home/nvimuser/work

--- a/neovim/docker/Dockerfile
+++ b/neovim/docker/Dockerfile
@@ -43,6 +43,7 @@ RUN yay -Sy --noconfirm \
     ripgrep \
     ruby-install \
     tig \
+    tmate \
     tmux \
     tree-sitter-cli \
     unzip \

--- a/neovim/docker/build
+++ b/neovim/docker/build
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+docker build \
+  --build-arg UID="$(id -u)" \
+  --build-arg GID="$(id -g)" \
+  -t nvim-sandbox \
+  "$SCRIPT_DIR"

--- a/tmate/.tmate.conf
+++ b/tmate/.tmate.conf
@@ -31,7 +31,7 @@ bind '"' split-window -c "#{pane_current_path}"
 bind % split-window -h -c "#{pane_current_path}"
 bind c new-window -c "#{pane_current_path}"
 
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$' || ps -o args= -t '#{pane_tty}' | grep -qE 'nvim-sandbox nvim($| )'"
 bind-key -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
 bind-key -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
 bind-key -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -41,7 +41,7 @@ bind-key          S choose-window "join-pane -v -s "%%""
 bind-key          V choose-window "join-pane -h -s "%%""
 bind-key          B "break-pane"
 
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$' || ps -o args= -t '#{pane_tty}' | grep -q nvim-sandbox"
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$' || ps -o args= -t '#{pane_tty}' | grep -qE 'nvim-sandbox nvim($| )'"
 bind-key -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
 bind-key -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
 bind-key -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -4,6 +4,9 @@
 set-option -sa terminal-overrides ",xterm*:Tc"
 set-option -g default-terminal "xterm-256color"
 
+# allow OSC 52 clipboard escape sequences to pass through
+set -g set-clipboard on
+
 # increase scroll-back history
 set -g history-limit 15000
 
@@ -38,7 +41,7 @@ bind-key          S choose-window "join-pane -v -s "%%""
 bind-key          V choose-window "join-pane -h -s "%%""
 bind-key          B "break-pane"
 
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$' || ps -o args= -t '#{pane_tty}' | grep -q nvim-sandbox"
 bind-key -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
 bind-key -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
 bind-key -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"


### PR DESCRIPTION
## Summary

Recent supply chain attacks on neovim plugins demonstrate that any plugin with code execution can silently exfiltrate SSH keys, GPG keys, cloud credentials, browser data, and anything else accessible to the user. This PR runs neovim and all plugins inside a Docker container, restricting what a compromised plugin can access.

## What's protected

Plugins can no longer reach:
- `~/.ssh` (private keys)
- `~/.gnupg` (GPG keys)
- `~/.aws`, `~/.kube`, `~/.docker` (cloud credentials)
- `~/.config/*` (except nvim config, read-only)
- Browser data, keyrings, application state

## What plugins can still do

- Read/write project files (necessary for editing)
- Git read operations (diff, log, blame, status)
- Network access (required for Copilot, Mason, plugin installs)
- Clipboard via OSC 52 through tmux

## How it works

- Arch Linux Docker image with neovim, toolchains (Go, Node, Ruby via chruby), LSP servers, and Claude Code baked in
- `bin/nvim` wrapper replaces the `nvim` command, launching the container transparently
- Project mounted at its real host path so git editor operations (rebase, commit) work seamlessly
- Per-project undo/cache directories keyed by project path hash
- Shared plugin storage across projects
- tmux socket mounted for vim-tmux-navigator integration
- `run_in_split` sends commands to host tmux panes with correct working directory

## Additional changes

- Fix nvim-treesitter-endwise config for new API (`init()` instead of `require('nvim-treesitter.configs')`)
- Fix gopls `make_range_params` deprecation warning
- Add `set-clipboard on` to tmux config for OSC 52 passthrough
- Skip `auto_create_directories` plugin for `.git` paths

## Helper scripts

- `nvim-ruby-install <version>` — install a Ruby version with LSP gems
- `nvim-bundle-install` — install project gems for the current directory